### PR TITLE
Build artifacts for npm with Babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,13 @@
+{
+  "presets": [
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": ["ie >= 11"],
+          "node": "4.0.0"
+        }
+      }
+    ]
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 *.log
+dist

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "object",
     "array"
   ],
-  "main": "objectAssignDeep.js",
+  "main": "dist/objectAssignDeep.js",
   "author": "Josh Cole <saikojosh@gmail.com> (http://www.JoshuaCole.me)",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     }
   ],
   "scripts": {
-    "build": "babel objectAssignDeep.js -d dist"
+    "build": "babel objectAssignDeep.js -d dist",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,13 @@
       "email": "saikojosh@gmail.com"
     }
   ],
+  "scripts": {
+    "build": "babel objectAssignDeep.js -d dist"
+  },
   "dependencies": {},
   "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
     "eslint": "latest",
     "eslint-config-recombix": "latest",
     "eslint-config-vue": "latest",


### PR DESCRIPTION
Addresses (possibly fixes) #4.

This PR adds Babel as a devDependency, using it to build a JavaScript artifact for release that is compatible down to Node.js 4 and IE11 (not quite ES5, but this should be enough compatibility for almost anyone).

Here's what the output looks like, vs the original source: https://www.diffchecker.com/DBqpq8i4